### PR TITLE
Bc/safe transfer

### DIFF
--- a/contracts/AugmentedBondingCurve.sol
+++ b/contracts/AugmentedBondingCurve.sol
@@ -60,6 +60,7 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
     string private constant ERROR_COLLATERAL_NOT_SENDER          = "MM_COLLATERAL_NOT_SENDER";
     string private constant ERROR_DEPOSIT_NOT_AMOUNT             = "MM_DEPOSIT_NOT_AMOUNT";
     string private constant ERROR_NO_PERMISSION                  = "MM_NO_PERMISSION";
+    string private constant ERROR_TOKEN_NOT_SENDER               = "MM_TOKEN_NOT_SENDER";
 
     struct Collateral {
         bool    whitelisted;
@@ -300,6 +301,7 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
      *      makeBuyOrder(address _buyer, address _collateral, uint256 _depositAmount, uint256 _minReturnAmountAfterFee)
     */
     function receiveApproval(address _from, uint256 _amount, address _token, bytes _buyOrderData) public {
+        require(_token == msg.sender, ERROR_TOKEN_NOT_SENDER);
         require(canPerform(_from, MAKE_BUY_ORDER_ROLE, new uint256[](0)), ERROR_NO_PERMISSION);
         require(ERC20(msg.sender).safeTransferFrom(_from, address(this), _amount), ERROR_TRANSFER_FAILED);
 

--- a/contracts/AugmentedBondingCurve.sol
+++ b/contracts/AugmentedBondingCurve.sol
@@ -301,7 +301,7 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
     */
     function receiveApproval(address _from, uint256 _amount, address _token, bytes _buyOrderData) public {
         require(canPerform(_from, MAKE_BUY_ORDER_ROLE, new uint256[](0)), ERROR_NO_PERMISSION);
-        require(ERC20(msg.sender).transferFrom(_from, address(this), _amount), ERROR_TRANSFER_FAILED);
+        require(ERC20(msg.sender).safeTransferFrom(_from, address(this), _amount), ERROR_TRANSFER_FAILED);
 
         _makeBuyOrderRaw(_from, msg.sender, _amount, _buyOrderData);
     }

--- a/contracts/AugmentedBondingCurve.sol
+++ b/contracts/AugmentedBondingCurve.sol
@@ -424,7 +424,7 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
      * @param _buyOrderData Data for the below function call
      *      makeBuyOrder(address _buyer, address _collateral, uint256 _depositAmount, uint256 _minReturnAmountAfterFee)
     */
-    function _makeBuyOrderRaw(address _from, address _token, uint256 _amount, bytes _buyOrderData)
+    function _makeBuyOrderRaw(address _from, address _token, uint256 _amount, bytes memory _buyOrderData)
         internal isInitialized
     {
         bytes memory buyOrderDataMemory = _buyOrderData;


### PR DESCRIPTION
Addressed feedback from sokhai:
- receiveApproval() should use safeTransferFrom() instead
- receiveApproval() may opt to use an additional msg.sender == _token check for clarity
- _makeBuyOrderRaw() should use the memory keyword for its bytes argument