### PR TITLE
[CHORE]: Refactor _collateralValueIsValid()

### DIFF
--- a/contracts/AugmentedBondingCurve.sol
+++ b/contracts/AugmentedBondingCurve.sol
@@ -347,21 +347,13 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
     function _collateralValueIsValid(address _buyer, address _collateral, uint256 _value, uint256 _msgValue, bool _noPreApproval)
         internal view returns (bool)
     {
-        if (_value == 0) {
-            return false;
-        }
-
         if (_collateral == ETH) {
             return _msgValue == _value;
         }
 
-        bool buyerAllowanceAvailable = !_noPreApproval &&
-            balanceOf(_buyer, _collateral) >= _value &&
-            ERC20(_collateral).allowance(_buyer, address(this)) >= _value;
-
         bool fundsAlreadyDeposited = _noPreApproval && balanceOf(address(this), _collateral) >= _value;
 
-        return _msgValue == 0 && (buyerAllowanceAvailable || fundsAlreadyDeposited);
+        return _msgValue == 0 && (fundsAlreadyDeposited);
     }
 
     function _bondAmountIsValid(address _seller, uint256 _amount) internal view returns (bool) {

--- a/contracts/AugmentedBondingCurve.sol
+++ b/contracts/AugmentedBondingCurve.sol
@@ -344,14 +344,14 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
         return _tokenManager.maxAccountTokens() == uint256(-1);
     }
 
-    function _collateralValueIsValid(address _buyer, address _collateral, uint256 _value, uint256 _msgValue, bool _noPreApproval)
+    function _collateralValueIsValid(address _buyer, uint256 _value, uint256 _msgValue, bool _noPreApproval)
         internal view returns (bool)
     {
-        if (_collateral == ETH) {
+        if (msg.sender == ETH) {
             return _msgValue == _value;
         }
 
-        bool fundsAlreadyDeposited = _noPreApproval && balanceOf(address(this), _collateral) >= _value;
+        bool fundsAlreadyDeposited = _noPreApproval && balanceOf(address(this), msg.sender) >= _value;
 
         return _msgValue == 0 && (fundsAlreadyDeposited);
     }
@@ -379,7 +379,7 @@ contract AugmentedBondingCurve is EtherTokenConstant, IsContract, ApproveAndCall
     {
         require(isOpen, ERROR_NOT_OPEN);
         require(_collateralIsWhitelisted(_collateral), ERROR_COLLATERAL_NOT_WHITELISTED);
-        require(_collateralValueIsValid(_buyer, _collateral, _depositAmount, msg.value, _noPreApproval), ERROR_INVALID_COLLATERAL_VALUE);
+        require(_collateralValueIsValid(_buyer, _depositAmount, msg.value, _noPreApproval), ERROR_INVALID_COLLATERAL_VALUE);
 
         // deduct fee
         uint256 fee = _depositAmount.mul(buyFeePct).div(PCT_BASE);


### PR DESCRIPTION
resolves #13
resolves #14 
(_maybe_)

This PR refactors `_collateralValueIsValid()`, replacing the use of an argument(`_collateral`) with `msg.sender` and removing the allowance check that was done by `buyerAllowanceAvailable`

Q) Are there any issues with using `msg.sender` directly? (I think the `_collateral` variable passed down is already checked to be a contract's address in the `_makeBuyOrderRaw()` function)?